### PR TITLE
Upgrade Log4j dependency to patch Log4Shell vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@ allprojects {
 
     dependencies {
         // The production code uses the SLF4J logging API at compile time
-        implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.2'
-        implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.2'
-        implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.11.2'
+        implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
+        implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
+        implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.16.0'
 
         implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.7'
 

--- a/src/main/java/tigerworkshop/webapphardwarebridge/Config.java
+++ b/src/main/java/tigerworkshop/webapphardwarebridge/Config.java
@@ -4,5 +4,5 @@ public class Config {
     public static String APP_NAME = "WebApp Hardware Bridge";
     public static String APP_ID = "tigerworkshop.webapphardwarebridge";
     public static final String DOCUMENT_PATH = "documents/";
-    public static String VERSION = "0.13.2";
+    public static String VERSION = "0.13.3";
 }


### PR DESCRIPTION
Log4Shell has been patched in Log4j version 2.16.0, so we're upgrading to that:
- CVE-2021-44228
- CVE-2021-45046